### PR TITLE
Expose Reporter.makeLogReporter()

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ Example output available in the [reporters](#reporters) section.
   | `--strictProjectName`  | Used in conjunction with `--project`. If specified, a stricter name matching will be done for the project name.  | No |
   | `--machine_name`  | If specified, the machine name will be used to create the `buildIdentifier`. If it is not specified, the host name will be used.  | No |
   | `--omit_warnings` | Omit the warnings details in the final report. This is useful if there are too many of them and the report's size is too big with them. | No |
+  | `--omit_notes` | Omit the notes details in the final report. This is useful if there are too many of them and the report's size is too big with them. | No |
 
   >No *: One of `--file`, `--project`, `--workspace`, `--xcodeproj` parameters is required.
 

--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -46,12 +46,8 @@ public class ActivityParser {
     public func parseActivityLogInURL(_ logURL: URL,
                                       redacted: Bool,
                                       withoutBuildSpecificInformation: Bool) throws -> IDEActivityLog {
-        let logLoader = LogLoader()
-        let content = try logLoader.loadFromURL(logURL)
-        let lexer = Lexer(filePath: logURL.path)
-        let tokens = try lexer.tokenize(contents: content,
-                                        redacted: redacted,
-                                        withoutBuildSpecificInformation: withoutBuildSpecificInformation)
+        let tokens = try getTokens(logURL, redacted: redacted,
+                                   withoutBuildSpecificInformation: withoutBuildSpecificInformation)
         return try parseIDEActiviyLogFromTokens(tokens)
     }
 
@@ -236,6 +232,21 @@ public class ActivityParser {
         return IDEActivityLogAnalyzerControlFlowStepEdge(
                                      startLocation: try parseDocumentLocation(iterator: &iterator),
                                      endLocation: try parseDocumentLocation(iterator: &iterator))
+    }
+
+    private func getTokens(_ logURL: URL,
+                           redacted: Bool,
+                           withoutBuildSpecificInformation: Bool) throws -> [Token] {
+        let logLoader = LogLoader()
+        var tokens: [Token] = []
+        try autoreleasepool {
+            let content = try logLoader.loadFromURL(logURL)
+            let lexer = Lexer(filePath: logURL.path)
+            tokens = try lexer.tokenize(contents: content,
+                                            redacted: redacted,
+                                            withoutBuildSpecificInformation: withoutBuildSpecificInformation)
+        }
+        return tokens
     }
 
     private func parseMessages(iterator: inout IndexingIterator<[Token]>) throws -> [IDEActivityLogMessage] {

--- a/Sources/XCLogParser/activityparser/ActivityParser.swift
+++ b/Sources/XCLogParser/activityparser/ActivityParser.swift
@@ -239,6 +239,13 @@ public class ActivityParser {
                            withoutBuildSpecificInformation: Bool) throws -> [Token] {
         let logLoader = LogLoader()
         var tokens: [Token] = []
+        #if os(Linux)
+        let content = try logLoader.loadFromURL(logURL)
+        let lexer = Lexer(filePath: logURL.path)
+        tokens = try lexer.tokenize(contents: content,
+                                        redacted: redacted,
+                                        withoutBuildSpecificInformation: withoutBuildSpecificInformation)
+        #else
         try autoreleasepool {
             let content = try logLoader.loadFromURL(logURL)
             let lexer = Lexer(filePath: logURL.path)
@@ -246,6 +253,7 @@ public class ActivityParser {
                                             redacted: redacted,
                                             withoutBuildSpecificInformation: withoutBuildSpecificInformation)
         }
+        #endif
         return tokens
     }
 

--- a/Sources/XCLogParser/commands/ActionOptions.swift
+++ b/Sources/XCLogParser/commands/ActionOptions.swift
@@ -49,13 +49,17 @@ public struct ActionOptions {
     /// If true, the parse command won't add the Warnings details to the output.
     public let omitWarningsDetails: Bool
 
+    /// If true, the parse command won't add the Notes details to the output.
+    public let omitNotesDetails: Bool
+
     public init(reporter: Reporter,
                 outputPath: String,
                 redacted: Bool,
                 withoutBuildSpecificInformation: Bool,
                 machineName: String? = nil,
                 rootOutput: String = "",
-                omitWarningsDetails: Bool = false) {
+                omitWarningsDetails: Bool = false,
+                omitNotesDetails: Bool = false) {
         self.reporter = reporter
         self.outputPath = outputPath
         self.redacted = redacted
@@ -63,5 +67,6 @@ public struct ActionOptions {
         self.machineName = machineName
         self.rootOutput = rootOutput
         self.omitWarningsDetails = omitWarningsDetails
+        self.omitNotesDetails = omitNotesDetails
     }
 }

--- a/Sources/XCLogParser/commands/CommandHandler.swift
+++ b/Sources/XCLogParser/commands/CommandHandler.swift
@@ -64,7 +64,8 @@ public struct CommandHandler {
                                                                         options.withoutBuildSpecificInformation)
 
         let buildParser = ParserBuildSteps(machineName: options.machineName,
-                                           omitWarningsDetails: options.omitWarningsDetails)
+                                           omitWarningsDetails: options.omitWarningsDetails,
+                                           omitNotesDetails: options.omitNotesDetails)
         let buildSteps = try buildParser.parse(activityLog: activityLog)
         let reporterOutput = ReporterOutputFactory.makeReporterOutput(path: options.outputPath)
         let logReporter = options.reporter.makeLogReporter()

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.23"
+    public static let current = "0.2.24"
 
 }

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.25"
+    public static let current = "0.2.26"
 
 }

--- a/Sources/XCLogParser/commands/Version.swift
+++ b/Sources/XCLogParser/commands/Version.swift
@@ -21,6 +21,6 @@ import Foundation
 
 public struct Version {
 
-    public static let current = "0.2.24"
+    public static let current = "0.2.25"
 
 }

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -56,7 +56,6 @@ extension Notice {
             if var notice = Notice(withType: NoticeType.fromTitle(noticeTypeTitle),
                                    logMessage: message,
                                    detail: logSection.text) {
-
                 // Add the right details to Swift errors
                 if notice.type == NoticeType.swiftError || notice.type == .swiftWarning {
                     // Special case, if Swiftc fails for a whole module,
@@ -68,7 +67,7 @@ extension Notice {
                         errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
                         // do not report error in a file that it does not belong to (we'll ended
                         // up having duplicated errors)
-                        if logSection.location.documentURLString != notice.documentURL {
+                        if !logSection.location.documentURLString.isEmpty && logSection.location.documentURLString != notice.documentURL {
                             return nil
                         }
                         notice = notice.with(detail: swiftErrorDetails[errorLocation])

--- a/Sources/XCLogParser/parser/Notice+Parser.swift
+++ b/Sources/XCLogParser/parser/Notice+Parser.swift
@@ -67,7 +67,8 @@ extension Notice {
                         errorLocation += ":\(notice.startingLineNumber):\(notice.startingColumnNumber):"
                         // do not report error in a file that it does not belong to (we'll ended
                         // up having duplicated errors)
-                        if !logSection.location.documentURLString.isEmpty && logSection.location.documentURLString != notice.documentURL {
+                        if !logSection.location.documentURLString.isEmpty
+                            && logSection.location.documentURLString != notice.documentURL {
                             return nil
                         }
                         notice = notice.with(detail: swiftErrorDetails[errorLocation])

--- a/Sources/XCLogParser/parser/ParserBuildSteps.swift
+++ b/Sources/XCLogParser/parser/ParserBuildSteps.swift
@@ -38,6 +38,10 @@ public final class ParserBuildSteps {
     /// Useful to save space.
     let omitWarningsDetails: Bool
 
+    /// If true, the Notes won't be parsed.
+    /// Usefult to save space.
+    let omitNotesDetails: Bool
+
     public lazy var dateFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.timeZone = TimeZone(abbreviation: "UTC")
@@ -73,13 +77,18 @@ public final class ParserBuildSteps {
 
     /// - parameter machineName: The name of the machine. It will be used to create a unique identifier
     /// for the log. If `nil`, the host name will be used instead.
-    public init(machineName: String? = nil, omitWarningsDetails: Bool) {
+    /// - parameter omitWarningsDetails: if true, the Warnings won't be parsed
+    /// - parameter omitNotesDetails: if true, the Notes won't be parsed
+    public init(machineName: String? = nil,
+                omitWarningsDetails: Bool,
+                omitNotesDetails: Bool) {
         if let machineName = machineName {
             self.machineName = machineName
         } else {
             self.machineName = MacOSMachineNameReader().machineName ?? "unknown"
         }
         self.omitWarningsDetails = omitWarningsDetails
+        self.omitNotesDetails = omitNotesDetails
     }
 
     /// Parses the content from an Xcode log into a `BuildStep`
@@ -154,7 +163,7 @@ public final class ParserBuildSteps {
                                  documentURL: logSection.location.documentURLString,
                                  warnings: omitWarningsDetails ? [] : warnings,
                                  errors: errors,
-                                 notes: notes,
+                                 notes: omitNotesDetails ? [] : notes,
                                  swiftFunctionTimes: nil,
                                  fetchedFromCache: wasFetchedFromCache(parent:
                                     parentSection, section: logSection),

--- a/Sources/XCLogParser/reporter/Reporter.swift
+++ b/Sources/XCLogParser/reporter/Reporter.swift
@@ -27,7 +27,7 @@ public enum Reporter: String {
     case html
     case issues
 
-    func makeLogReporter() -> LogReporter {
+    public func makeLogReporter() -> LogReporter {
         switch self {
         case .chromeTracer:
             return ChromeTracerReporter()

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -114,6 +114,13 @@ struct ParseCommand: ParsableCommand {
     """)
     var omitWarnings: Bool = false
 
+    @Flag(name: .customLong("omit_notes"),
+          help: """
+    If present, the report will omit the Notes found in the log.
+    Useful to reduce the size of the final report.
+    """)
+    var omitNotes: Bool = false
+
     mutating func validate() throws {
         if !hasValidLogOptions() {
             throw ValidationError("""

--- a/Sources/XCLogParserApp/commands/ParseCommand.swift
+++ b/Sources/XCLogParserApp/commands/ParseCommand.swift
@@ -162,7 +162,8 @@ struct ParseCommand: ParsableCommand {
                                           withoutBuildSpecificInformation: withoutBuildSpecificInformation,
                                           machineName: machineName,
                                           rootOutput: rootOutput ?? "",
-                                          omitWarningsDetails: omitWarnings)
+                                          omitWarningsDetails: omitWarnings,
+                                          omitNotesDetails: omitNotes)
         let action = Action.parse(options: actionOptions)
         let command = Command(logOptions: logOptions, action: action)
         try commandHandler.handle(command: command)


### PR DESCRIPTION
Make `Reporter.makeLogReporter()` public to allow manipulating `BuildStep`s before generating the HTML report